### PR TITLE
docs: remove extra alternatives for host.docker.internal from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,25 +20,7 @@ These instructions create a new project from scratch. The add-on cannot be added
 Obviously, this requires a working [DDEV](https://ddev.com/) installation.
 
 ### Docker provider
-This has been successfully tested with Orbstack, Colima, Rancher Desktop, and Docker Desktop. Colima and Docker Desktop work out-of-the-box. Orbstack and Rancher Desktop each require an extra step:
-
-#### Orbstack
-
-Override the default `$DISPLAY` environment variable in the container by adding the following to your `.ddev/config.yaml` file:
-
-```yaml
-web_environment:
-  - DISPLAY=host.orb.internal:0
-```
-
-#### Rancher Desktop
-
-Override the default `$DISPLAY` environment variable in the container by adding the following to your `.ddev/config.yaml` file:
-
-```yaml
-web_environment:
-  - DISPLAY=host.rancher-desktop.internal:0
-```
+This has been successfully tested with Orbstack, Colima, Rancher Desktop, and Docker Desktop. Colima and Docker Desktop work out-of-the-box.
 
 ### XQuartz
 


### PR DESCRIPTION
`host.docker.internal` is supported by all the Docker providers, and DDEV provides it in general. Unless something really interesting is going on, there's no need for the `host.orb.internal` and such. If you can demonstrate a problem, I'd be happy to take a look with you.

And... because you have no issue queue... I can't ask why the default branch is "develop" instead of "main". Why?