### PR TITLE
Add `xb-autosave` command

### DIFF
--- a/commands/web/xb-autosave
+++ b/commands/web/xb-autosave
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Enable, disable, or clear auto-save
+## Usage: xb-autosave on|off|enable|disable|true|false|toggle|status|clear
+## Example: ddev autosave         # Enable auto-save.\nddev autosave on      # Enable auto-save.\nddev autosave off     # Disable auto-save.\nddev autosave toggle  # Toggle auto-save status.\nddev autosave status  # Get auto-save status.\nddev autosave clear   # Clear all auto-saves.
+## Aliases: autosave,as
+## ExecRaw: false
+## Flags: []
+## AutocompleteTerms: ["on","off","enable","disable","toggle","status","clear"]
+
+enable_autosave() {
+  drush state:delete experience_builder.disable_auto-save
+}
+
+disable_autosave() {
+  drush state:set experience_builder.disable_auto-save 1
+}
+
+if [ $# -eq 0 ] ; then
+  enable_autosave
+  exit
+fi
+
+get_autosave_status() {
+  if [ "$(drush state:get experience_builder.disable_auto-save)" = "1" ]; then
+    echo "0"
+  else
+    echo "1"
+  fi
+}
+
+case $1 in
+  on|true|enable)
+    enable_autosave
+    ;;
+  off|false|disable)
+    disable_autosave
+    ;;
+  toggle)
+    if [ "$(get_autosave_status)" = "1" ]; then
+      disable_autosave
+    else
+      enable_autosave
+    fi
+    ;;
+  status)
+    if [ "$(get_autosave_status)" = "1" ]; then
+      echo "autosave enabled"
+    else
+      echo "autosave disabled"
+    fi
+    ;;
+  clear)
+    drush \
+      sql:query \
+      "delete from key_value_expire where collection='tempstore.shared.experience_builder.auto_save'" \
+      > /dev/null
+    ;;
+  *)
+    echo "Invalid argument: $1"
+    ;;
+esac

--- a/install.yaml
+++ b/install.yaml
@@ -10,6 +10,7 @@ project_files:
   - commands/host/xb-cypress-open
   - commands/host/xb-cypress-run
   - commands/host/xb-setup
+  - commands/web/xb-autosave
   - commands/web/xb-drush-si
   - commands/web/xb-eslint
   - commands/web/xb-npm-build


### PR DESCRIPTION
This adds a new command to interact with the Experience Builder auto-save feature:

```
$ ddev autosave -h
Enable, disable, or clear auto-save (shell web container command)

Usage:
  ddev xb-autosave on|off|enable|disable|true|false|toggle|status|clear [flags]

Aliases:
  xb-autosave, autosave, as

Examples:
  ddev autosave         # Enable auto-save.
  ddev autosave on      # Enable auto-save.
  ddev autosave off     # Disable auto-save.
  ddev autosave toggle  # Toggle auto-save status.
  ddev autosave status  # Get auto-save status.
  ddev autosave clear   # Clear all auto-saves.

Flags:
  -h, --help   help for xb-autosave

Global Flags:
  -j, --json-output   If true, user-oriented output will be in JSON format.
      --skip-hooks    If true, any hook normally run by the command will be skipped.

```