### PR TITLE
Add `static` command to run all static analysis tools

### DIFF
--- a/commands/host/xb-static
+++ b/commands/host/xb-static
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Run all static analysis tools.
+## Usage: xb-static
+## Example: ddev static
+## Aliases: static
+## Flags: []
+## ExecRaw: true
+
+echo Running PHPCS...
+ddev phpcs
+
+echo
+echo Running ESLint...
+ddev eslint
+
+echo
+echo Running Stylelint...
+ddev stylelint
+
+echo
+echo Running PHPStan...
+ddev phpstan

--- a/install.yaml
+++ b/install.yaml
@@ -10,6 +10,7 @@ project_files:
   - commands/host/xb-cypress-open
   - commands/host/xb-cypress-run
   - commands/host/xb-setup
+  - commands/host/xb-static
   - commands/web/xb-autosave
   - commands/web/xb-eslint
   - commands/web/xb-npm-build


### PR DESCRIPTION
This runs PHPCS, ESLint, Stylelint, and PHPStan.
