### PR TITLE
Run PHPUnit with core settings

### DIFF
--- a/commands/web/xb-phpunit
+++ b/commands/web/xb-phpunit
@@ -8,5 +8,5 @@
 cd "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT" || exit 1
 
 ../vendor/bin/phpunit \
-  --bootstrap core/tests/bootstrap.php \
+  -c core/phpunit.xml.dist \
   modules/contrib/experience_builder/"$*"


### PR DESCRIPTION
Running with the core config file sets the bootstrap but also sets the test printer and a few other config options.