### PR TITLE
Add `fix` command to run all static analysis automatic fixer tools

### DIFF
--- a/commands/host/xb-fix
+++ b/commands/host/xb-fix
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Run all static analysis automatic fixer tools.
+## Usage: xb-fix
+## Example: ddev fix
+## Aliases: fix
+## Flags: []
+## ExecRaw: true
+
+echo Running PHPCBF...
+ddev phpcs fix
+
+echo
+echo Running ESLint fixer...
+ddev eslint fix
+
+echo
+echo Running Stylelint fixer...
+ddev stylelint fix

--- a/install.yaml
+++ b/install.yaml
@@ -6,6 +6,7 @@ name: drupal-xb-dev
 
 project_files:
   - commands/host/xb-cypress
+  - commands/host/xb-fix
   - commands/host/xb-setup
   - commands/host/xb-static
   - commands/web/xb-autosave


### PR DESCRIPTION
This runs PHPCBF and the ESLint and Stylelint fixers.