### PR TITLE
Introduce `xb-ui-dev` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Any time you update the Experience Builder module or modify its front-end code, 
 ddev ui-build
 ```
 
+When developing the React app, enable the `xb_vite` module (`ddev drush en xb_vite -y`), and run:
+
+```shell
+ddev xb-ui-dev
+```
+
 To completely reinstall Drupal and the Experience Builder module, run:
 
 ```shell

--- a/commands/web/xb-ui-dev
+++ b/commands/web/xb-ui-dev
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Install dependencies and run Experience Builder's UI app development server.
+## Example: ddev xb-ui-dev
+## Aliases: ui-dev,dev
+
+cd "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/modules/contrib/experience_builder/ui" || exit 1
+
+npm install
+npm run drupaldev -- --host

--- a/config.drupal-xb-dev.yaml
+++ b/config.drupal-xb-dev.yaml
@@ -5,7 +5,7 @@ web_environment:
   - DB_URL=sqlite://web/sites/default/files/db.sqlite
   - DISPLAY=host.docker.internal:0
   - DRUPAL_TEST_DB_URL=sqlite://web/sites/default/files/db.sqlite
-  - VITE_SERVER_ORIGIN=http://localhost:5173
+  - VITE_SERVER_ORIGIN=https://${DDEV_HOSTNAME}:5174
 webimage_extra_packages:
   - libasound2
   - libgbm-dev
@@ -17,3 +17,8 @@ webimage_extra_packages:
   - libxtst6
   - xauth
   - xvfb
+web_extra_exposed_ports:
+  - name: vite-dev-server
+    container_port: 5173
+    http_port: 5173
+    https_port: 5174


### PR DESCRIPTION
The add-on currently provides the `xb-ui-build` command, which creates artifacts that are optimized for production use. The XB React app also defines a script that's better suited for development: it runs Vite's dev server that's not only faster, but also provides hot module replacement for a convenient workflow.

I propose that we expose this script through a new command, `xb-ui-build`. To make the script work, we also need to expose ports, which we can do via [DDEV's `web_extra_exposed_ports` config option](https://ddev.readthedocs.io/en/stable/users/configuration/config/#web_extra_exposed_ports). Additionally, the `VITE_SERVER_ORIGIN` environment variable needs to use the DDEV project's hostname.

**Important note!** The following Experience Builder issue needs to land in order for this command to work:
[#3485543: Support the `VITE_SERVER_ORIGIN` environment variable in the `xb_vite` module](https://www.drupal.org/project/experience_builder/issues/3485543).