### PR TITLE
Fixes #21: Add `xb-core-set-version` command

### DIFF
--- a/commands/web/xb-core-set-version
+++ b/commands/web/xb-core-set-version
@@ -2,7 +2,7 @@
 
 ## #ddev-generated
 ## Description: Change the version of Drupal core.
-## Example: ddev xb-set-core-version 11.1
+## Example: ddev xb-core-set-version 11.1
 
 cd "$DDEV_COMPOSER_ROOT" || exit 1
 

--- a/commands/web/xb-core-set-version
+++ b/commands/web/xb-core-set-version
@@ -2,7 +2,12 @@
 
 ## #ddev-generated
 ## Description: Change the version of Drupal core.
+## Usage: xb-core-set-version <core-version>
+## ExecRaw: true
 ## Example: ddev xb-core-set-version 11.1
+## Aliases: core
+## Flags: []
+## ExecRaw: true
 
 cd "$DDEV_COMPOSER_ROOT" || exit 1
 

--- a/commands/web/xb-core-set-version
+++ b/commands/web/xb-core-set-version
@@ -3,14 +3,28 @@
 ## #ddev-generated
 ## Description: Change the version of Drupal core.
 ## Usage: xb-core-set-version <core-version>
-## ExecRaw: true
-## Example: ddev xb-core-set-version 11.1
+## Example: ddev core ^11           # Use the latest 11.x.\nddev core 11.0.7        # Use a specific version.\nddev core "^10 || ^11"  # Use the latest 10.x or 11.x.
 ## Aliases: core
 ## Flags: []
 ## ExecRaw: true
 
 cd "$DDEV_COMPOSER_ROOT" || exit 1
 
-composer require --no-update --dev drupal/core-dev:^$*
-composer require --no-update drupal/core-recommended:^$* drupal/core-composer-scaffold:^$* drupal/core-project-message:^$*
+if [ "$#" -ne 1 ]; then
+  echo "Error: provide exactly one argument"
+  echo "Usage: core <core-version>"
+  exit 1
+fi
+
+CORE_VERSION=$1
+
+composer require  \
+  --dev \
+  --no-update \
+  "drupal/core-dev:$CORE_VERSION"
+composer require \
+  --no-update \
+  "drupal/core-recommended:$CORE_VERSION" \
+  "drupal/core-composer-scaffold:$CORE_VERSION" \
+  "drupal/core-project-message:$CORE_VERSION"
 composer update --with-all-dependencies

--- a/commands/web/xb-set-core-version
+++ b/commands/web/xb-set-core-version
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Change the version of Drupal core.
+## Example: ddev xb-set-core-version 11.1
+
+cd "$DDEV_COMPOSER_ROOT" || exit 1
+
+composer require --no-update --dev drupal/core-dev:^$*
+composer require --no-update drupal/core-recommended:^$* drupal/core-composer-scaffold:^$* drupal/core-project-message:^$*
+composer update --with-all-dependencies

--- a/install.yaml
+++ b/install.yaml
@@ -10,6 +10,7 @@ project_files:
   - commands/host/xb-setup
   - commands/host/xb-static
   - commands/web/xb-autosave
+  - commands/web/xb-core-set-version
   - commands/web/xb-eslint
   - commands/web/xb-phpcs
   - commands/web/xb-phpstan


### PR DESCRIPTION
I use this to quickly swap versions when testing against both Drupal 10 and 11.

```
$ ddev xb-set-core-version 11.1
...

$ ddev test tests/src/Functional/PropSourceEndpointTest.php 
PHPUnit 10.5.38 by Sebastian Bergmann and contributors.
...

$ ddev xb-set-core-version 10.4
...

$ ddev test tests/src/Functional/PropSourceEndpointTest.php 
PHPUnit 9.6.21 by Sebastian Bergmann and contributors.
...
```
