### PR TITLE
Prevent `xb-setup` command from prompting to trust Composer plugins

### DIFF
--- a/commands/host/xb-setup
+++ b/commands/host/xb-setup
@@ -52,6 +52,7 @@ git clone \
 ddev composer \
   require \
   --no-install \
+  --no-interaction \
   drush/drush
 
 # Require the Experience Builder module. Still don't install.
@@ -61,12 +62,14 @@ ddev composer config \
   web/modules/contrib/experience_builder
 ddev composer require \
   --no-install \
+  --no-interaction \
   drupal/experience_builder
 
 # Require dev dependencies. NOW install.
 ddev composer require \
   --dev \
   --update-with-all-dependencies \
+  --no-interaction \
   devizzent/cebe-php-openapi \
   league/openapi-psr7-validator \
   webflo/drupal-finder


### PR DESCRIPTION
This prevents the `xb-setup` command from stopping for input during execution to ask for permission to install Composer plugins.