### PR TITLE
Install `xb_test_node` on site install

### DIFF
--- a/commands/web/xb-site-install
+++ b/commands/web/xb-site-install
@@ -12,7 +12,9 @@ drush site:install -y \
   --site-name="XB Local Dev"
 
 # Enable the Experience Builder module.
-drush en -y experience_builder xb_test_node
+drush pm:install -y \
+  experience_builder \
+  xb_test_node
 
 # Create a default article.
 drush php:eval "(\Drupal\node\Entity\Node::create(['type' => 'article', 'title' => 'Test', 'uid' => 1]))->save();"

--- a/commands/web/xb-site-install
+++ b/commands/web/xb-site-install
@@ -12,7 +12,7 @@ drush site:install -y \
   --site-name="XB Local Dev"
 
 # Enable the Experience Builder module.
-drush en -y experience_builder
+drush en -y experience_builder xb_test_node
 
 # Create a default article.
 drush php:eval "(\Drupal\node\Entity\Node::create(['type' => 'article', 'title' => 'Test', 'uid' => 1]))->save();"


### PR DESCRIPTION
Following https://www.drupal.org/project/experience_builder/issues/3498085 we will also need to install `xb_test_node` for the Article content type to have the demo field.