### PR TITLE
Add missing Composer dependencies to fix PHPStan

### DIFF
--- a/commands/host/xb-setup
+++ b/commands/host/xb-setup
@@ -55,7 +55,7 @@ ddev composer \
   --no-interaction \
   drush/drush
 
-# Require the Experience Builder module. Still don't install.
+# Require the Experience Builder module and soft dependencies. Still don't install.
 ddev composer config \
   repositories.xb \
   path \
@@ -63,16 +63,19 @@ ddev composer config \
 ddev composer require \
   --no-install \
   --no-interaction \
-  drupal/experience_builder
+  drupal/experience_builder \
+  drupal/metatag:^2.1
 
 # Require dev dependencies. NOW install.
 ddev composer require \
   --dev \
   --update-with-all-dependencies \
   --no-interaction \
-  devizzent/cebe-php-openapi \
-  league/openapi-psr7-validator \
-  webflo/drupal-finder
+  drupal/core-dev \
+  devizzent/cebe-php-openapi:^1.0.3 \
+  jangregor/phpstan-prophecy:^1.0.2 \
+  league/openapi-psr7-validator:^0.22.0 \
+  webflo/drupal-finder:^1.3.1
 
 # Install Drupal and enable the Experience Builder module.
 ddev xb-site-install


### PR DESCRIPTION
The `xb-phpstan` command is currently broken due to the absence of `drupal/core-dev` (which I felt just sure was already there) and an unsatisfied soft dependency on `drupal/metatag`. This adds them and updates the other dev dependencies to match `experience_builder`'s `composer.json`, including version constraints.