### PR TITLE
Add `xb_dev_standard` to `xb-site-install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,19 @@ The installation process clones [the Experience Builder module](https://www.drup
 Any time you update the Experience Builder module or modify its front-end code, be sure to rebuild the UI app assets:
 
 ```shell
-ddev ui-build
+ddev xb-ui-build
 ```
 
 When developing the React app, make sure to use the HTTPS URL of your DDEV project, then run:
 
 ```shell
-ddev ui-dev
+ddev xb-ui-dev
 ```
 
 To completely reinstall Drupal and the Experience Builder module, run:
 
 ```shell
-ddev site-install
+ddev xb-site-install
 ```
 
 For the full list of available Experience Builder commands, run this:

--- a/commands/web/xb-site-install
+++ b/commands/web/xb-site-install
@@ -12,7 +12,9 @@ drush site:install -y \
   --site-name="XB Local Dev"
 
 # Enable the Experience Builder module.
-drush en -y experience_builder
+drush pm:install -y \
+  experience_builder \
+  xb_dev_standard
 
 # Create a default article.
 drush php:eval "(\Drupal\node\Entity\Node::create(['type' => 'article', 'title' => 'Test', 'uid' => 1]))->save();"


### PR DESCRIPTION
As described in https://github.com/TravisCarden/ddev-drupal-xb-dev/issues/29 this adds in xb_dev_standard to the module installation and updates prefixes for DDEV commands in the README. 

This allows a user to run `ddev xb-setup` and upon logging into the site for the first time they can use Experience Builder on the automatically created test article as part of `xb-site-install`