### PR TITLE
WIP: Ensures mutagen syncs and Drush is available for xb-site-install

### DIFF
--- a/commands/host/xb-setup
+++ b/commands/host/xb-setup
@@ -92,6 +92,24 @@ composer require \
 printf '\n# Allow test modules and themes to be installed.\n$settings["extension_discovery_scan_tests"] = TRUE;' \
   >> web/sites/default/settings.ddev.php
 
+echo "Sleep to ensure mutagen syncs";
+sleep 15;
+
+# Wait for Drush to become available.
+# This can happen due to delays in mutagen sync.
+echo "Waiting for Drush to become available..."
+TIMEOUT=60
+ELAPSED=0
+while ! ddev drush status >/dev/null 2>&1; do
+  if [ $ELAPSED -ge $TIMEOUT ]; then
+    echo "Error: Timed out waiting for Drush to become available after ${TIMEOUT} seconds."
+    exit 1
+  fi
+  echo "Waiting for Drush... ($ELAPSED/${TIMEOUT}s)"
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+done
+
 # Install Drupal and enable the Experience Builder module.
 ddev xb-site-install
 


### PR DESCRIPTION
Drush was erroring as unavailable and this seems to be from a delay in mutagen syncing. Considered checking mutagen status but that also seems to have a slight delay. Rather than place a sleep command generally we loop to see when Drush becomes available and timeout if it does not become available

I'm not convinced this is the best approach but wanted to get it for review as it does seem to allow getting a start to finish install against the latest HEAD and Drupal 10.x 

### Context
When testing HEAD against 10.x and the installation I was getting the following error upon `ddeb xb-site-install`:

```
Run "composer audit" for a full list of advisories.
drush is not available. You may need to 'ddev composer require drush/drush'
drush is not available. You may need to 'ddev composer require drush/drush'
drush is not available. You may need to 'ddev composer require drush/drush'
drush is not available. You may need to 'ddev composer require drush/drush'
drush is not available. You may need to 'ddev composer require drush/drush'
Failed to run xb-site-install : exit status 1
Failed to run xb-setup ; error=exit status 1
```

Following the same steps against v0.0.22 doesn't cause this issue. There is nothing in the diff that seems to be causing this problem though aside from more of the steps running in sequence with no delay. 

If I wait a few seconds and then rerun `ddev xb-setup --force` everything succeeds without an issue. The problem in that case is we get a CORS issue when trying to edit via XB so something still didn't install successfully. 

