### PR TITLE
Eliminate `ddev composer` shell alias in `xb-setup`

### DIFF
--- a/commands/host/xb-setup
+++ b/commands/host/xb-setup
@@ -11,9 +11,6 @@ cd "$(dirname "$0")" || exit
 cd ../../../
 set -e
 
-# Route Composer commands through DDEV.
-alias composer="ddev composer"
-
 # Flag-handling.
 while :; do
   case ${1:-} in
@@ -53,31 +50,31 @@ git clone \
   web/modules/contrib/experience_builder
 
 # Allow all Composer plugins.
-composer config \
+ddev composer config \
   --no-plugins \
   allow-plugins.\* \
   true
 
 # Require Drush, but don't install yet for performance reasons.
-composer require \
+ddev composer require \
   --no-install \
   --update-with-all-dependencies \
   --no-interaction \
   drush/drush
 
 # Require the Experience Builder module. Still don't install.
-composer config \
+ddev composer config \
   repositories.xb \
   path \
   web/modules/contrib/experience_builder
-composer require \
+ddev composer require \
   --no-install \
   --update-with-all-dependencies \
   --no-interaction \
   drupal/experience_builder
 
 # Require dev dependencies. NOW install.
-composer require \
+ddev composer require \
   --dev \
   --update-with-all-dependencies \
   --no-interaction \


### PR DESCRIPTION
This alias doesn't seem to be working consistently and bash docs recommend not setting in a file like this but rather alias as a function or variable.

This seems to be the actual root cause of https://github.com/TravisCarden/ddev-drupal-xb-dev/pull/34 

Reverting this makes everything work properly on initial setup of HEAD. It seems like the bash manual also recommends not setting an alias this way: https://www.gnu.org/software/bash/manual/html_node/Aliases.html

> Aliases are not expanded when the shell is not interactive, unless the expand_aliases shell option is set using shopt 

Alternative solution: We could also set this as a variable instead so we can set the path/location of composer once and retain the original intent of the alias. 