### PR TITLE
Use full command names in `xb-static`, not aliases

### DIFF
--- a/commands/host/xb-static
+++ b/commands/host/xb-static
@@ -9,16 +9,16 @@
 ## ExecRaw: true
 
 echo Running PHPCS...
-ddev phpcs
+ddev xb-phpcs
 
 echo
 echo Running ESLint...
-ddev eslint
+ddev xb-eslint
 
 echo
 echo Running Stylelint...
-ddev stylelint
+ddev xb-stylelint
 
 echo
 echo Running PHPStan...
-ddev phpstan
+ddev xb-phpstan


### PR DESCRIPTION
If you happen to have `phpcs`, `phpstan`, etc commands on your project, you will see warnings like:

```
Command 'xb-phpcs' cannot have alias 'phpcs' that is already in use by command 'phpcs', skipping it
Command 'xb-phpstan' cannot have alias 'phpstan' that is already in use by command 'phpstan', skipping it
Command 'xb-stylelint' cannot have alias 'stylelint' that is already in use by command 'stylelint', skipping it
```

But you can always use the `xb-`prefixed commands.

However, `xb-static` is using the aliases, so you would be running the wrong commands, and might not even notice!
This PR changes that to call directly the `xb-`prefixed commands instead.