### PR TITLE
Update dependencies and installation instructions for Drupal 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ mkdir ~/Sites/xb-dev
 cd ~/Sites/xb-dev
 
 # Configure the new DDEV project.
-ddev config --project-type=drupal --php-version=8.3 --docroot=web
+ddev config --project-type=drupal11 --docroot=web
 
 # Create the Drupal project.
-ddev composer create drupal/recommended-project:10.x@dev --no-install
+ddev composer create drupal/recommended-project:11.x@dev --no-install
 
 # Install the add-on.
 ddev add-on get drupal-xb/ddev-drupal-xb-dev

--- a/commands/host/xb-setup
+++ b/commands/host/xb-setup
@@ -78,9 +78,9 @@ ddev composer require \
   --dev \
   --update-with-all-dependencies \
   --no-interaction \
-  devizzent/cebe-php-openapi:^1.0.3 \
+  devizzent/cebe-php-openapi:^1.1.4 \
   drupal/metatag:^2. \
-  jangregor/phpstan-prophecy:^1.0.2 \
+  jangregor/phpstan-prophecy:^2.2.0 \
   league/openapi-psr7-validator:^0.22.0 \
   webflo/drupal-finder:^1.3.1
 


### PR DESCRIPTION
Experience Builder now requires Drupal 11, so let's update the installation instructions and dependencies.

This closes the following outstanding issues/PRs:

1. Fixes #33
2. Fixes https://github.com/drupal-xb/ddev-drupal-xb-dev/issues/39#issuecomment-2745922606
3. Closes #40 