### PR TITLE
Update deprecated `ddev composer  create` in `README.md`, use `ddev composer  create-project` instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cd ~/Sites/xb-dev
 ddev config --project-type=drupal11 --docroot=web
 
 # Create the Drupal project.
-ddev composer create drupal/recommended-project:11.x@dev --no-install
+ddev composer create-project drupal/recommended-project:11.x@dev --no-install
 
 # Install the add-on.
 ddev add-on get drupal-xb/ddev-drupal-xb-dev


### PR DESCRIPTION
```shell
$ ddev composer create drupal/recommended-project:11.x@dev --no-install
Command "create" is deprecated, please start using the identical "ddev composer create-project" instead
```