### PR TITLE
fix: For xb-phpunit command, don't quote arguments, so multiple arguments can be passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ This creates and configures a DDEV project for local [Drupal Canvas](https://www
 - [Installation](#installation)
 - [Usage](#usage)
 - [Updating](#updating)
-- [Cypress](#cypress)
-  - [Setup](#setup)
-  - [Usage](#usage-1)
+- [Automatic tests](#automatic-tests)
+  - [PHPUnit tests](#phpunit)
+  - [Cypress](#cypress)
+    - [Setup](#setup)
+    - [Running Cypress tests](#running-cypress-tests)
 - [Support \& community](#support--community)
 - [FAQ \& known issues](#faq--known-issues)
   - [Can I use Cypress on Linux or Windows?](#can-i-use-cypress-on-linux-or-windows)
@@ -84,14 +86,32 @@ ddev | grep xb-
 
 Update the Drupal Canvas module clone just like you would any other Git repo. No tools are currently provided for updating Core.
 
-## Cypress
+## Automatic tests
+
+### PHPUnit
+
+For PHPUnit based tests (`Unit`, `Kernel`, `Functional`, and `FunctionalJavascript`), the `xb-phpunit` command is provided.
+The test file must be passed relative to the canvas module root.
+
+```shell
+ddev xb-phpunit tests/src/Functional/CanvasConfigEntityHttpApiTest.php
+```
+
+Whatever extra argument `phpunit` accepts can be used:
+
+```shell
+ddev xb-phpunit tests/src/Functional/CanvasConfigEntityHttpApiTest.php --filter testJavascriptComponent
+
+```
+
+### Cypress
 
 Drupal Canvas uses [Cypress](https://www.cypress.io/) for front-end testing. It is currently only supported on macOS.
 Linux and Windows with WSL2 might work with the instructions below.
 
-### Setup
+#### Setup
 
-#### macOS
+##### macOS
 
 > Carefully follow the below XQuartz configuration steps after installing it. Failure to do so will result in frustrating, difficult to debug problems.
 
@@ -111,14 +131,14 @@ Configure XQuartz to allow connections from the host:
 
 ![XQuartz Preferences dialog](resources/xquartz-settings.png)
 
-#### Windows
+##### Windows
 
 > **Note:** This is experimental and officially unsupported. Members of the community who use Windows may be able to provide unofficial support. See [Support \& community](#support--community). Be sure to thank them. They're giving up their personal time to help you.
 
 Install [VcXsrv Windows X Server](https://sourceforge.net/projects/vcxsrv) in the default "C:/Program Files" location.
 You might need to restart your system afterwards.
 
-### Usage
+#### Running Cypress tests
 
 Run Cypress tests interactively:
 

--- a/commands/web/xb-phpunit
+++ b/commands/web/xb-phpunit
@@ -9,4 +9,4 @@ cd "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT" || exit 1
 
 ../vendor/bin/phpunit \
   -c core/phpunit.xml.dist \
-  modules/contrib/canvas/"$*"
+  modules/contrib/canvas/$*


### PR DESCRIPTION
With xb-phpunit script you can run:

`ddev xb-phpunit tests/src/Functional/CanvasConfigEntityHttpApiTest.php`

but extra arguments produce failures, e.g.

`ddev xb-phpunit tests/src/Functional/CanvasConfigEntityHttpApiTest.php --filter testJavascriptComponent`

I've been using this patch since forever but forgot to actually create a PR.