### PR TITLE
Allow additional arguments to be passed to PHPUnit.

### DIFF
--- a/commands/web/xb-phpunit
+++ b/commands/web/xb-phpunit
@@ -9,4 +9,4 @@ cd "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT" || exit 1
 
 ../vendor/bin/phpunit \
   -c core/phpunit.xml.dist \
-  modules/contrib/canvas/$*
+  modules/contrib/canvas/"$1" "${@:2}"


### PR DESCRIPTION
It is useful to be able to pass additional arguments to phpunit to run individual tests.

Before:
```
$ ddev xb-phpunit tests/src/Kernel/Plugin/Field/FieldType/ComponentTreeItemResolvedTest.php --filter testResolvedInvalidatedOnInputChange
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Test file "modules/contrib/canvas/tests/src/Kernel/Plugin/Field/FieldType/ComponentTreeItemResolvedTest.php --filter testResolvedInvalidatedOnInputChange" not found
```

After:
```
$ ddev xb-phpunit tests/src/Kernel/Plugin/Field/FieldType/ComponentTreeItemResolvedTest.php --filter testResolvedInvalidatedOnInputChange
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.17
Configuration: /var/www/html/web/core/phpunit.xml.dist

F                                                                   1 / 1 (100%)

Time: 00:06.871, Memory: 25.30 MB

There was 1 failure:

1) Drupal\Tests\canvas\Kernel\Plugin\Field\FieldType\ComponentTreeItemResolvedTest::testResolvedInvalidatedOnInputChange
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'Updated heading'
+'Original heading'
```
