### PR TITLE
fix: Clear xb-autosave from key_value store after tempstore migration (#56)

### DIFF
--- a/commands/web/xb-autosave
+++ b/commands/web/xb-autosave
@@ -1,39 +1,21 @@
 #!/bin/bash
 
 ## #ddev-generated
-## Description: Enable, disable, or clear auto-save
-## Usage: xb-autosave [on|off|enable|disable|true|false|toggle|status|clear]
-## Example: ddev autosave         # Enable auto-save.\nddev autosave on      # Enable auto-save.\nddev autosave off     # Disable auto-save.\nddev autosave toggle  # Toggle auto-save status.\nddev autosave status  # Get auto-save status.\nddev autosave clear   # Clear all auto-saves.
+## Description: Clear auto-save
+## Usage: xb-autosave clear
+## Example: ddev autosave clear   # Clear all auto-saves.
 ## Aliases: autosave,as
 ## ExecRaw: false
 ## Flags: []
-## AutocompleteTerms: ["on","off","enable","disable","toggle","status","clear"]
-
-enable_autosave() {
-  drush state:delete canvas.disable_auto-save
-}
-
-disable_autosave() {
-  drush state:set canvas.disable_auto-save 1
-}
-
-get_autosave_status() {
-  [[ "$(drush state:get canvas.disable_auto-save)" == "1" ]] && echo "0" || echo "1"
-}
+## AutocompleteTerms: ["clear"]
 
 clear_autosave() {
   drush sql:query "delete from key_value where collection='canvas.auto_save'" > /dev/null
 }
 
-# The default action is to enable auto-save.
-[[ $# -eq 0 ]] && enable_autosave && exit
-
 # Process command arguments.
 case "$1" in
-  on|true|enable) enable_autosave ;;
-  off|false|disable) disable_autosave ;;
-  toggle) if [[ "$(get_autosave_status)" == "1" ]]; then disable_autosave; else enable_autosave; fi ;;
-  status) if [[ "$(get_autosave_status)" == "1" ]]; then echo "autosave enabled"; else echo "autosave disabled"; fi ;;
   clear) clear_autosave ;;
+  "") echo "Usage: ddev xb-autosave clear" >&2; exit 1 ;;
   *) echo "Invalid argument: $1" >&2; exit 1 ;;
 esac

--- a/commands/web/xb-autosave
+++ b/commands/web/xb-autosave
@@ -22,7 +22,7 @@ get_autosave_status() {
 }
 
 clear_autosave() {
-  drush sql:query "delete from key_value_expire where collection='tempstore.shared.canvas.auto_save'" > /dev/null
+  drush sql:query "delete from key_value where collection='canvas.auto_save'" > /dev/null
 }
 
 # The default action is to enable auto-save.


### PR DESCRIPTION
  Canvas switched from the expirable tempstore to a regular key-value  store for auto-saved changes ([drupal.org #3554205](https://www.drupal.org/project/canvas/issues/3554205)), so the old  `key_value_expire` / `tempstore.shared.canvas.auto_save` query no longer finds anything. Delete from `key_value` with collection `canvas.auto_save` instead.

The `canvas.disable_auto-save` state key was removed from Canvas in  [a8d4ac12](https://git.drupalcode.org/project/canvas/-/commit/a8d4ac12cd0f3b1ffbf1261b537888b02e444497) ([#3481736, "Adapt E2E tests to work with auto-save"](https://www.drupal.org/project/canvas/issues/3481736)), so `ddev xb-autosave on|off|toggle|status` has been silently no-op'ing against a state key nothing reads. Drop those subcommands and keep only `clear`, which still reflects real behavior.'

Fixes #56