### PR TITLE
fix: Make canvas paths docroot-aware in host commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ mkdir ~/Sites/xb-dev
 cd ~/Sites/xb-dev
 
 # Configure the new DDEV project.
-ddev config --project-type=drupal11 --docroot=web
+ddev config --project-type=drupal11
 
 # Create the Drupal project.
 ddev composer create-project drupal/recommended-project:11.x@dev --no-install
@@ -40,7 +40,7 @@ ddev composer create-project drupal/recommended-project:11.x@dev --no-install
 # Install the add-on.
 ddev add-on get drupal-canvas/ddev-drupal-xb-dev
 
-# Perform one-time setup operations.
+# Perform one-time setup operations, including composer installing Drupal Canvas itself.
 ddev xb-setup
 
 # Optionally add some convenience extras for development.
@@ -56,7 +56,7 @@ ddev xb-workspaces-dev
 
 The resulting DDEV project is just like any other one. Interact with it using the [the built-in commands](https://ddev.readthedocs.io/en/stable/users/usage/commands/), e.g., `ddev launch` to browse the site.
 
-The installation process clones [the Drupal Canvas module](https://www.drupal.org/project/canvas) into `web/modules/contrib/canvas`. Develop and contribute from either location like you would any other Git repo for a normal Drupal project.
+The installation process clones [the Drupal Canvas module](https://www.drupal.org/project/canvas) into the project installer path for contrib modules (typically `web/modules/contrib/canvas` for `docroot: web`, or `modules/contrib/canvas` for `docroot: ""`). Develop and contribute from there like you would any other Git repo for a normal Drupal project.
 
 Any time you update the Drupal Canvas module or modify its front-end code, be sure to rebuild the UI app assets:
 

--- a/commands/host/.xb-command-helpers.sh
+++ b/commands/host/.xb-command-helpers.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Shared helpers for host-side xb commands.
+
+resolve_canvas_dir() {
+  ddev exec -- php -r '
+$composer = json_decode((string) file_get_contents("composer.json"), true);
+$paths = $composer["extra"]["installer-paths"] ?? [];
+foreach ($paths as $path => $conditions) {
+  if (in_array("type:drupal-module", $conditions, true)) {
+    echo str_replace("{\$name}", "canvas", $path);
+    exit(0);
+  }
+}
+echo "modules/contrib/canvas";
+'
+}
+
+init_canvas_paths() {
+  local script_dir="$1"
+  local docroot_prefix
+
+  CANVAS_DIR_RELATIVE="$(resolve_canvas_dir)"
+  CANVAS_DIR_ON_HOST="$script_dir/../../../$CANVAS_DIR_RELATIVE"
+  CANVAS_DIR_INSIDE_CONTAINER="/var/www/html/$CANVAS_DIR_RELATIVE"
+  CANVAS_UI_DIR_INSIDE_CONTAINER="$CANVAS_DIR_INSIDE_CONTAINER/ui"
+
+  docroot_prefix="${CANVAS_DIR_RELATIVE%/modules/contrib/canvas}"
+  if [ "$docroot_prefix" = "$CANVAS_DIR_RELATIVE" ]; then
+    docroot_prefix=""
+  fi
+  SETTINGS_DDEV_PATH="${docroot_prefix:+$docroot_prefix/}sites/default/settings.ddev.php"
+  CORE_DIR_IN_CONTAINER="/var/www/html/${docroot_prefix:+$docroot_prefix/}core"
+}

--- a/commands/host/xb-cypress
+++ b/commands/host/xb-cypress
@@ -12,8 +12,24 @@
 
 cd "$(dirname "$0")" || exit 1
 
-CYPRESS_BIN="$(dirname "$0")/../../../web/modules/contrib/canvas/node_modules/cypress/bin/cypress"
-CYPRESS_BIN_INSIDE_CONTAINER="/var/www/html/web/modules/contrib/canvas/node_modules/cypress/bin/cypress"
+resolve_canvas_dir() {
+  ddev exec -- php -r '
+$composer = json_decode((string) file_get_contents("composer.json"), true);
+$paths = $composer["extra"]["installer-paths"] ?? [];
+foreach ($paths as $path => $conditions) {
+  if (in_array("type:drupal-module", $conditions, true)) {
+    echo str_replace("{\$name}", "canvas", $path);
+    exit(0);
+  }
+}
+echo "modules/contrib/canvas";
+'
+}
+
+CANVAS_DIR="$(resolve_canvas_dir)"
+CYPRESS_BIN="$(dirname "$0")/../../../$CANVAS_DIR/node_modules/cypress/bin/cypress"
+CYPRESS_BIN_INSIDE_CONTAINER="/var/www/html/$CANVAS_DIR/node_modules/cypress/bin/cypress"
+CANVAS_UI_DIR_INSIDE_CONTAINER="/var/www/html/$CANVAS_DIR/ui"
 
 # Check for the presence of Cypress.
 if ! command -v "$CYPRESS_BIN" &>/dev/null; then
@@ -62,7 +78,7 @@ xhost +
 function xb_cypress {
   # This needs to be the binary path inside the container.
   ddev exec \
-    --dir /var/www/html/web/modules/contrib/canvas/ui \
+    --dir "$CANVAS_UI_DIR_INSIDE_CONTAINER" \
     "$CYPRESS_BIN_INSIDE_CONTAINER $1"
 }
 

--- a/commands/host/xb-cypress
+++ b/commands/host/xb-cypress
@@ -10,26 +10,12 @@
 ## OSTypes: darwin,linux
 ## ExecRaw: true
 
-cd "$(dirname "$0")" || exit 1
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/.xb-command-helpers.sh"
+init_canvas_paths "$SCRIPT_DIR"
 
-resolve_canvas_dir() {
-  ddev exec -- php -r '
-$composer = json_decode((string) file_get_contents("composer.json"), true);
-$paths = $composer["extra"]["installer-paths"] ?? [];
-foreach ($paths as $path => $conditions) {
-  if (in_array("type:drupal-module", $conditions, true)) {
-    echo str_replace("{\$name}", "canvas", $path);
-    exit(0);
-  }
-}
-echo "modules/contrib/canvas";
-'
-}
-
-CANVAS_DIR="$(resolve_canvas_dir)"
-CYPRESS_BIN="$(dirname "$0")/../../../$CANVAS_DIR/node_modules/cypress/bin/cypress"
-CYPRESS_BIN_INSIDE_CONTAINER="/var/www/html/$CANVAS_DIR/node_modules/cypress/bin/cypress"
-CANVAS_UI_DIR_INSIDE_CONTAINER="/var/www/html/$CANVAS_DIR/ui"
+CYPRESS_BIN="$CANVAS_DIR_ON_HOST/node_modules/cypress/bin/cypress"
+CYPRESS_BIN_INSIDE_CONTAINER="$CANVAS_DIR_INSIDE_CONTAINER/node_modules/cypress/bin/cypress"
 
 # Check for the presence of Cypress.
 if ! command -v "$CYPRESS_BIN" &>/dev/null; then

--- a/commands/host/xb-playwright
+++ b/commands/host/xb-playwright
@@ -10,23 +10,9 @@
 ## OSTypes: darwin,linux
 ## ExecRaw: true
 
-resolve_canvas_dir() {
-  ddev exec -- php -r '
-$composer = json_decode((string) file_get_contents("composer.json"), true);
-$paths = $composer["extra"]["installer-paths"] ?? [];
-foreach ($paths as $path => $conditions) {
-  if (in_array("type:drupal-module", $conditions, true)) {
-    echo str_replace("{\$name}", "canvas", $path);
-    exit(0);
-  }
-}
-echo "modules/contrib/canvas";
-'
-}
-
-CANVAS_DIR_RELATIVE="$(resolve_canvas_dir)"
-CANVAS_DIR_INSIDE_CONTAINER="/var/www/html/$CANVAS_DIR_RELATIVE"
-CANVAS_DIR_ON_HOST="$(dirname "$0")/../../../$CANVAS_DIR_RELATIVE"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/.xb-command-helpers.sh"
+init_canvas_paths "$SCRIPT_DIR"
 
 # Check that Playwright is installed (npm install has run).
 if [[ ! -x "$CANVAS_DIR_ON_HOST/node_modules/.bin/playwright" ]]; then

--- a/commands/host/xb-playwright
+++ b/commands/host/xb-playwright
@@ -10,8 +10,23 @@
 ## OSTypes: darwin,linux
 ## ExecRaw: true
 
-CANVAS_DIR_INSIDE_CONTAINER="/var/www/html/web/modules/contrib/canvas"
-CANVAS_DIR_ON_HOST="$(dirname "$0")/../../../web/modules/contrib/canvas"
+resolve_canvas_dir() {
+  ddev exec -- php -r '
+$composer = json_decode((string) file_get_contents("composer.json"), true);
+$paths = $composer["extra"]["installer-paths"] ?? [];
+foreach ($paths as $path => $conditions) {
+  if (in_array("type:drupal-module", $conditions, true)) {
+    echo str_replace("{\$name}", "canvas", $path);
+    exit(0);
+  }
+}
+echo "modules/contrib/canvas";
+'
+}
+
+CANVAS_DIR_RELATIVE="$(resolve_canvas_dir)"
+CANVAS_DIR_INSIDE_CONTAINER="/var/www/html/$CANVAS_DIR_RELATIVE"
+CANVAS_DIR_ON_HOST="$(dirname "$0")/../../../$CANVAS_DIR_RELATIVE"
 
 # Check that Playwright is installed (npm install has run).
 if [[ ! -x "$CANVAS_DIR_ON_HOST/node_modules/.bin/playwright" ]]; then

--- a/commands/host/xb-setup
+++ b/commands/host/xb-setup
@@ -11,6 +11,28 @@ cd "$(dirname "$0")" || exit
 cd ../../../
 set -e
 
+resolve_canvas_dir() {
+  ddev exec -- php -r '
+$composer = json_decode((string) file_get_contents("composer.json"), true);
+$paths = $composer["extra"]["installer-paths"] ?? [];
+foreach ($paths as $path => $conditions) {
+  if (in_array("type:drupal-module", $conditions, true)) {
+    echo str_replace("{\$name}", "canvas", $path);
+    exit(0);
+  }
+}
+echo "modules/contrib/canvas";
+'
+}
+
+CANVAS_DIR="$(resolve_canvas_dir)"
+DOCROOT_PREFIX="${CANVAS_DIR%/modules/contrib/canvas}"
+if [ "$DOCROOT_PREFIX" = "$CANVAS_DIR" ]; then
+  DOCROOT_PREFIX=""
+fi
+SETTINGS_DDEV_PATH="${DOCROOT_PREFIX:+$DOCROOT_PREFIX/}sites/default/settings.ddev.php"
+CORE_DIR_IN_CONTAINER="/var/www/html/${DOCROOT_PREFIX:+$DOCROOT_PREFIX/}core"
+
 # Flag-handling.
 while :; do
   case ${1:-} in
@@ -28,7 +50,7 @@ while :; do
 done
 
 # Exit early if the environment is already set up.
-if [ -d web/modules/contrib/canvas/.git ] && [ ! "$FORCE" ]; then
+if [ -d "$CANVAS_DIR/.git" ] && [ ! "$FORCE" ]; then
   GREEN="\033[0;32m"
   NO_COLOR="\033[0m"
   printf "%bThe Drupal Canvas development environment is already set up.%b\n" "$GREEN" "$NO_COLOR"
@@ -40,14 +62,14 @@ if [ -d web/modules/contrib/canvas/.git ] && [ ! "$FORCE" ]; then
 fi
 
 # Remove the Drupal Canvas module if it's there.
-rm -rf web/modules/contrib/canvas
-mkdir -p web/modules/contrib
+rm -rf "$CANVAS_DIR"
+mkdir -p "$(dirname "$CANVAS_DIR")"
 
 # Place the Drupal Canvas module via Git for development. Require
 # it with Composer to test its composer.json and place dependencies.
 git clone \
   git@git.drupal.org:project/canvas.git \
-  web/modules/contrib/canvas
+  "$CANVAS_DIR"
 
 # Allow all Composer plugins.
 ddev composer config \
@@ -66,7 +88,7 @@ ddev composer require \
 ddev composer config \
   repositories.xb \
   path \
-  web/modules/contrib/canvas
+  "$CANVAS_DIR"
 ddev composer require \
   --no-install \
   --update-with-all-dependencies \
@@ -87,13 +109,13 @@ ddev composer require \
 # Allow test modules and themes to be installed.
 # shellcheck disable=SC2016
 printf '\n# Allow test modules and themes to be installed.\n$settings["extension_discovery_scan_tests"] = TRUE;' \
-  >> web/sites/default/settings.ddev.php
+  >> "$SETTINGS_DDEV_PATH"
 
 # Install Drupal and enable the Drupal Canvas module.
 ddev xb-site-install
 
 # Install Drupal core NPM packages.
-ddev exec --dir /var/www/html/web/core -- npm install
+ddev exec --dir "$CORE_DIR_IN_CONTAINER" -- npm install
 
 # Build front-end assets.
 ddev xb-ui-build

--- a/commands/host/xb-setup
+++ b/commands/host/xb-setup
@@ -7,31 +7,14 @@
 ## Flags: [{"Name":"force","Shorthand":"f","Usage":"Completely reset an existing environment if present and start over"}]
 ## ExecRaw: true
 
-cd "$(dirname "$0")" || exit
-cd ../../../
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/.xb-command-helpers.sh"
+
+cd "$SCRIPT_DIR/../../../" || exit
 set -e
 
-resolve_canvas_dir() {
-  ddev exec -- php -r '
-$composer = json_decode((string) file_get_contents("composer.json"), true);
-$paths = $composer["extra"]["installer-paths"] ?? [];
-foreach ($paths as $path => $conditions) {
-  if (in_array("type:drupal-module", $conditions, true)) {
-    echo str_replace("{\$name}", "canvas", $path);
-    exit(0);
-  }
-}
-echo "modules/contrib/canvas";
-'
-}
-
-CANVAS_DIR="$(resolve_canvas_dir)"
-DOCROOT_PREFIX="${CANVAS_DIR%/modules/contrib/canvas}"
-if [ "$DOCROOT_PREFIX" = "$CANVAS_DIR" ]; then
-  DOCROOT_PREFIX=""
-fi
-SETTINGS_DDEV_PATH="${DOCROOT_PREFIX:+$DOCROOT_PREFIX/}sites/default/settings.ddev.php"
-CORE_DIR_IN_CONTAINER="/var/www/html/${DOCROOT_PREFIX:+$DOCROOT_PREFIX/}core"
+init_canvas_paths "$SCRIPT_DIR"
+CANVAS_DIR="$CANVAS_DIR_RELATIVE"
 
 # Flag-handling.
 while :; do

--- a/install.yaml
+++ b/install.yaml
@@ -5,6 +5,7 @@
 name: drupal-xb-dev
 
 project_files:
+  - commands/host/.xb-command-helpers.sh
   - commands/host/xb-cypress
   - commands/host/xb-fix
   - commands/host/xb-playwright


### PR DESCRIPTION
Derive the canvas module location from composer installer-paths so xb-setup, xb-cypress, and xb-playwright work with both docroot=web and docroot="" projects (including Drupal core-style checkouts with drupal-dev). Also update README setup/usage wording to reflect docroot-agnostic behavior.

LLM assistance was used to build this PR